### PR TITLE
fix page range error

### DIFF
--- a/scrape_civitai.py
+++ b/scrape_civitai.py
@@ -12,7 +12,7 @@ pages = int(config["DEFAULT"]["Pages"])
 page_start = int(config["DEFAULT"]["PageStart"])
 local_images = config["DEFAULT"]["LocalImages"] == 'True'
 
-for i in range(page_start, pages + 1):
+for i in range(page_start, pages + page_start):
     url = f"https://civitai.com/api/v1/images?limit=100&sort=Most Reactions&nsfw={nsfw_level}&page={i}"
     print(url)
     response = requests.get(url)


### PR DESCRIPTION
Hi,
Thanks for your awesome work, it's very helpful for me.
I found that there was an issue about the page range. The second argument to the `range` function was passed incorrectly.
The definition is `range (start, stop)`, the `stop` indicates where the series of numbers stops.
The initial purpose for `Pages` and `PageStart` configurations was indicating scrape the `Pages` pages from `PageStart`.
So I updated the code.
